### PR TITLE
FEATURE: Support UseCases of Monocle 7.4

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -10,6 +10,10 @@ Sitegeist:
       # will be included, by default all propSets from the styleguide are included
       propSetOptIn: false
 
+      # if enabled only useCases from prototypes that have @styleguide.options.backstop.useCases = true
+      # will be included, by default all useCases from the styleguide are included
+      useCaseOptIn: false
+
       # template for the generated backstop.json file
       # the keys 'id','viewports','scenarios' and 'pathes' are
       # replaced by the backstop:configuration command

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Sitegeist:
       # will be included, by default all propSets from the styleguide are included
       propSetOptIn: false
 
+      # if enabled only useCases from prototypes that have @styleguide.options.backstop.useCases = true
+      # will be included, by default all useCases from the styleguide are included
+      useCaseOptIn: false
+
       # template for the generated backstop.json file
       # the keys 'id','viewports','scenarios' and 'pathes' are
       # replaced by the backstop:configuration command
@@ -106,6 +110,10 @@ prototype(Vendor.Site:Component) < prototype(Neos.Fusion:Component) {
                 # depends on `propSetOptIn` settings   
                 propSets = true
 
+                # enable or disable the useCases inclusion, the default
+                # depends on `useCaseOptIn` settings   
+                useCases = true
+                
                 # configure scenario settings 
                 scenario {
                   delay = 2000

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "neos/neos": "~5.0 || ~7.0 || dev-master",
         "neos/fusion": "~5.0 || ~7.0 || dev-master",
-        "sitegeist/monocle": "~7.2 || dev-master",
+        "sitegeist/monocle": "~7.4 || dev-master",
         "neos/utility-arrays": "*"
     },
     "autoload": {


### PR DESCRIPTION
The useCases that are added in Monocle 7.4 are now supported in BackstopJS aswell. 
If enabled globally or for a prototype all scenarios for all useCases are defined.

## Settings 

```
Sitegeist:
  Monocle:
    BackstopJS:
      # if enabled only useCases from prototypes that have @styleguide.options.backstop.useCases = true
      # will be included, by default all useCases from the styleguide are included
      useCaseOptIn: false
```

## `@styleguideAnnotations`

```
prototype(Vendor.Site:Component) < prototype(Neos.Fusion:Component) {
    @styleguide {
        options {
            backstop {
                # enable or disable the useCases inclusion, the default
                # depends on `useCaseOptIn` settings   
                useCases = true
            }
        }
    }
}
```
 