### PR TITLE
FEATURE: Add inheritable viewport configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,49 @@ prototype(Vendor.Site:Component) < prototype(Neos.Fusion:Component) {
 ### Advanced scenarios 
 
 BackstopJS offers quite a bit of settings to adjust specific scenarios which is documented here https://github.com/garris/BackstopJS#advanced-scenarios. 
-While the general scenario template can be adjusted via Settings.yaml the scenario configuration of each prototyoe can
-be adjusted by the fusion  annotations `@styleguide.options.backstop.scenario`. All keys defined here there will override 
+While the general scenario template can be adjusted via Settings.yaml the scenario configuration of each prototype can
+be adjusted by the fusion  annotations `@styleguide.options.backstop.scenario`. All keys defined there will override 
 the generated scenario.
+
+### Advanced viewports
+
+Each scenario can rely on its own set of viewports which are sourced from settings in the following order:
+
+1. `@styleguide.options.backstop.scenario.viewports`
+2. `Sitegeist.Monocle.BackstopJS.scenarioTemplate.viewports` via `Settings.yaml`
+3. `Sitegeist.Monocle.ui.viewportPresets` via `Settings.yaml`
+
+This example demonstrates using a predefined viewport from the default settings of `Sitegeist.Monocle` alongside a 
+custom defined viewport.
+
+```
+prototype(Vendor.Site:Component) < prototype(Neos.Fusion:Component) {
+  @styleguide.options.backstop.scenario.viewports {
+    md = true
+    custom {
+      label = "custom"
+      width = 375
+      height = 112
+    }
+  }
+}
+```
+
+You can also define viewports only as presets with `enabled: false` inside the `scenarioTemplate` setting.
+```yaml
+Sitegeist:
+  Monocle:
+    packages:
+      'Vendor.Site':
+        BackstopJS:
+          scenarioTemplate:
+            viewports:
+              auto:
+                enabled: false
+                label: auto
+                width: 1
+                height: 1
+```
 
 ## Common problems and solutions 
 


### PR DESCRIPTION
With this PR a user can enable a subset of the predefined viewports in addition to individually defined ones inside of `@styleguide` information.

This improves the reusability of preset viewports and makes it easier to run only the necessary tests.

```yaml
Sitegeist:
  Monocle:
    ui:
      viewportPresets:
        xs:
          label: 'xtra small'
          width: 400
          height: 600
        md:
          label: 'medium'
          width: 600
          height: 400
        l:
          label: 'wide'
          width: 800
          height: 600
    packages:
      Vendor.Site:
        BackstopJS:
          scenarioTemplate:
            viewports:
              auto:
                enabled: false
                label: auto
                width: 1
                height: 1
```
Now each prototype can select which of the presets are used for testing:

```neosfusion
prototype(Vendor.Site:Component) < prototype(Neos.Fusion:Component) {
  @styleguide.options.backstop.default = true
  // uses xs, md and l viewports. The auto viewport is disabled and therefore only used as preset
}

prototype(Vendor.Site:Component2) < prototype(Neos.Fusion:Component) {
  @styleguide.options.backstop {
    default = true
    scenario.viewports.auto = true
    // uses auto preset and no other viewports 
    }
}

prototype(Vendor.Site:Component3) < prototype(Neos.Fusion:Component) {
  @styleguide.options.backstop {
    default = true
    scenario.viewports {
      md = true
      auto = true
      custom {
        label = "custom"
        width = 375
        height = 112
      }
    }
    // uses md and auto preset and a custom defined preset
    }
}
```
